### PR TITLE
Update CI to latest patterns

### DIFF
--- a/.github/workflows/go-build-and-test.yaml
+++ b/.github/workflows/go-build-and-test.yaml
@@ -12,7 +12,15 @@ permissions: {}
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Go Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      fail-fast: false
     permissions:
       contents: read
     steps:
@@ -23,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: '1.25'
+        go-version-file: go.mod
         check-latest: true
         cache: true
 

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -12,7 +12,23 @@ on:
 permissions: {}
 
 jobs:
+  resolve-versions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      stable: ${{ steps.versions.outputs.GO_MINOR_VERSION_STABLE }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Determine Go versions
+        id: versions
+        uses: carabiner-dev/actions/go/versions@360ffa1eb909b0105d4eccb6d6ef337911c34952 # main
+
   golangci:
+    needs: resolve-versions
     name: lint
     runs-on: ubuntu-latest
     permissions:
@@ -24,11 +40,11 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version: ${{ needs.resolve-versions.outputs.stable }}
           check-latest: true
           cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.7
+          version: v2.11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       
     steps:
       - name: Setup bnd
-        uses: carabiner-dev/bnd-actions/setup@HEAD
+        uses: carabiner-dev/actions/install/bnd@ba6f58b7120233bc312a76fb6bf3397704bcdcef # v1.1.5
 
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,19 +31,16 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
           cache: false
 
       - name: Install tejolote
-        uses: kubernetes-sigs/release-actions/setup-tejolote@ab33480f30919958240822cfc29af8d9903f313b # v0.4.1
-
-      - name: Install bom
-        uses: kubernetes-sigs/release-actions/setup-bom@ab33480f30919958240822cfc29af8d9903f313b # v0.4.1
+        uses: kubernetes-sigs/release-actions/setup-tejolote@cbe0488670ad0c0ff422fbef963da3bfe451a891 # v0.4.2
 
       - name: Set tag output
         id: tag
         run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
-  
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         id: goreleaser
@@ -61,13 +58,13 @@ jobs:
             tejolote attest --artifacts github://${{github.repository}}/${{ steps.tag.outputs.tag_name }} github://${{github.repository}}/"${GITHUB_RUN_ID}" --output provenance.json
             bnd statement provenance.json -o vexflow-${{ steps.tag.outputs.tag_name }}.provenance.json
             gh release upload ${{ steps.tag.outputs.tag_name }} vexflow-${{ steps.tag.outputs.tag_name }}.provenance.json
-            bnd push github ${{github.repository}} vexflow-${{ steps.tag.outputs.tag_name }}.provenance.json
+            bnd push ${{github.repository}} vexflow-${{ steps.tag.outputs.tag_name }}.provenance.json
 
       - name: Generate SBOM
-        shell: bash
+        id: sbom
+        uses: carabiner-dev/actions/unpack/sbom@ba6f58b7120233bc312a76fb6bf3397704bcdcef # v1.1.5
+        with:
+          push-to-release: ${{ steps.tag.outputs.tag_name }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          bom generate --format=json -o /tmp/vexflow-${{ steps.tag.outputs.tag_name }}.spdx.json .
-          gh release upload ${{ steps.tag.outputs.tag_name }} /tmp/vexflow-${{ steps.tag.outputs.tag_name }}.spdx.json
           

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -143,7 +143,7 @@ func WithProduct(prod *vex.Product) FilterFunc {
 	return func(si *StatementIndex) Filter {
 		return func() map[*vex.Statement]struct{} {
 			ret := map[*vex.Statement]struct{}{}
-			ids := []string{}
+			ids := make([]string, 0, len(prod.Identifiers)+len(prod.Hashes))
 			for _, id := range prod.Identifiers {
 				ids = append(ids, id)
 			}
@@ -169,7 +169,7 @@ func WithSubcomponent(subc *vex.Subcomponent) FilterFunc {
 	return func(si *StatementIndex) Filter {
 		return func() map[*vex.Statement]struct{} {
 			ret := map[*vex.Statement]struct{}{}
-			ids := []string{}
+			ids := make([]string, 0, len(subc.Identifiers)+len(subc.Hashes))
 			for _, id := range subc.Identifiers {
 				ids = append(ids, id)
 			}
@@ -234,7 +234,7 @@ func unionIndexResults(results []map[*vex.Statement]struct{}) []*vex.Statement {
 
 // Matches applies filters to the index to look for matching statements
 func (si *StatementIndex) Matches(filterfunc ...FilterFunc) []*vex.Statement {
-	lists := []map[*vex.Statement]struct{}{}
+	lists := make([]map[*vex.Statement]struct{}, 0, len(filterfunc))
 	for _, ffunc := range filterfunc {
 		filter := ffunc(si)
 		lists = append(lists, filter())

--- a/pkg/api/v1/vulnerability.go
+++ b/pkg/api/v1/vulnerability.go
@@ -53,7 +53,7 @@ func (vuln *Vulnerability) ComponentPurl() string {
 }
 
 func (vuln *Vulnerability) ToVex() *vex.Vulnerability {
-	aliases := []vex.VulnerabilityID{}
+	aliases := make([]vex.VulnerabilityID, 0, len(vuln.Aliases))
 	for _, a := range vuln.Aliases {
 		aliases = append(aliases, vex.VulnerabilityID(a))
 	}

--- a/pkg/flow/implementation.go
+++ b/pkg/flow/implementation.go
@@ -196,7 +196,7 @@ func (di *defaultImplementation) dedupeVulns(vulns []*api.Vulnerability) []*api.
 		}
 	}
 
-	ret := []*api.Vulnerability{}
+	ret := make([]*api.Vulnerability, 0, len(index))
 	for _, v := range index {
 		ret = append(ret, v)
 	}

--- a/pkg/scanner/osv-cmdline/scanner_test.go
+++ b/pkg/scanner/osv-cmdline/scanner_test.go
@@ -20,8 +20,8 @@ func TestProcessOSVreport(t *testing.T) {
 	require.NotNil(t, vulns)
 	require.Len(t, vulns, 4)
 
-	ids := []string{}
-	packages := []string{}
+	ids := make([]string, 0, len(vulns))
+	packages := make([]string, 0, len(vulns))
 	for _, v := range vulns {
 		ids = append(ids, v.ID)
 		packages = append(packages, v.Component.Purl)


### PR DESCRIPTION
This pull request updates CI workflows to improve cross-platform testing, automate version resolution, and modernize dependency management for Go and release tooling. The main changes focus on enhancing compatibility, maintainability, and automation in the GitHub Actions workflows.

**CI/CD Workflow Improvements**

* [`.github/workflows/go-build-and-test.yaml`](diffhunk://#diff-af9b960b730818c2a2c2ea6cc668715fcb5cfee8f37122d571e82e6963a5f86dL15-R23): Updated the test job to run on Ubuntu, macOS, and Windows using a matrix strategy, ensuring cross-platform test coverage. The Go version is now read from `go.mod` for consistency. [[1]](diffhunk://#diff-af9b960b730818c2a2c2ea6cc668715fcb5cfee8f37122d571e82e6963a5f86dL15-R23) [[2]](diffhunk://#diff-af9b960b730818c2a2c2ea6cc668715fcb5cfee8f37122d571e82e6963a5f86dL26-R34)

**Automated Version Management and Linting**

* [`.github/workflows/golangci-lint.yaml`](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0R15-R31): Introduced a `resolve-versions` job to dynamically determine the latest stable Go version, which is then used by the linting job. Updated `golangci-lint` to version `v2.11` for improved linting capabilities. [[1]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0R15-R31) [[2]](diffhunk://#diff-663d31008ec91b12d46959a84b8604f87c6be56c98db4dc4278411da292115f0L27-R50)

**Release Workflow Modernization**

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL24-R24): Switched to versioned actions for setting up BND and Tejolote, improved Go version management by using `go-version-file`, and replaced manual SBOM generation with a dedicated action for improved reliability and maintainability. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL24-R24) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL34-R38) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL64-L72)