### PR TITLE
Fix triage processing and attestation publishing bugs

### DIFF
--- a/internal/cmd/assemble.go
+++ b/internal/cmd/assemble.go
@@ -166,6 +166,14 @@ generated to STDOUT (or to the path specified by --out).
 			}
 
 			var out io.Writer = os.Stdout
+			if opts.OutPath != "" {
+				f, err := os.Create(opts.OutPath)
+				if err != nil {
+					return fmt.Errorf("opening output file: %w", err)
+				}
+				defer f.Close() //nolint:errcheck
+				out = f
+			}
 			return doc.ToJSON(out)
 		},
 	}

--- a/pkg/flow/implementation.go
+++ b/pkg/flow/implementation.go
@@ -296,6 +296,7 @@ func (di *defaultImplementation) TriagesToAttestation(triages []*api.Triage) (*i
 			continue
 		}
 		subjects = append(subjects, t.Branch.ToResourceDescriptor())
+		done[t.Branch.Identifier()] = struct{}{}
 	}
 	return intoto.NewStatement(
 		intoto.WithPredicate(predicate),

--- a/pkg/publish/dir/publisher.go
+++ b/pkg/publish/dir/publisher.go
@@ -72,8 +72,25 @@ func (p *Publisher) PublishDocument(doc *vex.VEX) (*api.StatementNotice, error) 
 	}, nil
 }
 
+// PublishAttestation extracts the VEX document from the attestation predicate
+// and writes it to the configured directory via PublishDocument.
 func (p *Publisher) PublishAttestation(att ampel.Statement) (*api.StatementNotice, error) {
-	return nil, fmt.Errorf("PublishAttestation not yet implemented")
+	pred := att.GetPredicate()
+	if pred == nil {
+		return nil, fmt.Errorf("attestation has no predicate")
+	}
+
+	data := pred.GetData()
+	if len(data) == 0 {
+		return nil, fmt.Errorf("attestation predicate has no data")
+	}
+
+	doc, err := vex.Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing VEX document from predicate: %w", err)
+	}
+
+	return p.PublishDocument(doc)
 }
 
 func (p *Publisher) ReadBranchVEX(branch *api.Branch) ([]ampel.Envelope, error) {

--- a/pkg/triage/github/handler.go
+++ b/pkg/triage/github/handler.go
@@ -289,7 +289,8 @@ func (th *TriageHandler) ReadTriageStatus(t *api.Triage) error {
 			}
 
 			if err := validateSlashCommand(slashCommand); err != nil {
-				return err
+				logrus.Warnf("Ignoring invalid slash command %q from comment #%d: %s", slashCommand.Command, i, err)
+				continue
 			}
 
 			currentStatus = api.StatusWaitingForStatement


### PR DESCRIPTION
Three bugs found while running vexflow in a compliance pipeline:

**1. Duplicate VEX statements in published attestation**
When duplicate triage issues existed for the same CVE, `TriagesToAttestation` included duplicate statements. AMPEL rejected the malformed VEX document. Fixed by deduplicating statements before publishing.

**2. `--out` flag silently ignored in `assemble`**
The flag was declared but the code always wrote to stdout. Any pipeline step using `--out <file>` produced an empty file. Fixed by wiring `opts.OutPath` to open a file writer when specified.

**3. Invalid slash commands abort triage processing**
A malformed slash command (e.g. a typo in a comment) caused `return err` in the handler, stopping all subsequent comment processing for that issue. Valid triage commands posted after a bad one were silently ignored. Fixed by logging a warning and continuing instead of returning.